### PR TITLE
Add support for draft and prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Options:
   -t, --tag <tag>      tag
   -n, --name <name>    name
   -b, --body <body>    body
+  -d, --draft          draft
+  -p, --prerelease     prerelease
 ```
 
 ### Upload

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,13 @@ github.authenticate({
 
 const getReleaseByTag = (options) => {
     return new Promise((resolve, reject) => {
-        github.repos.getReleaseByTag(options, (err, res) => {
-            err ? reject(err) : resolve(res);
+        github.repos.getReleases(options, (err, res) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            const releases = res.filter(r => r.tag_name === options.tag || r.name === options.tag);
+            releases.length ? resolve(releases[0]) : reject('Cannot find release');
         });
     });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,6 @@ const getReleaseByTag = (options) => {
             }
         } catch (err) {
             reject(err);
-            return;
         }
     });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,9 @@ program
     .option('-r, --repo <repo>', 'repo')
     .option('-t, --tag <tag>', 'tag')
     .option('-n, --name <name>', 'name')
-    .option('-b, --body <body>', 'body', false);
+    .option('-b, --body <body>', 'body', false)
+    .option('-d, --draft', 'draft')
+    .option('-p, --prerelease', 'prerelease');
 
 program.parse(process.argv);
 
@@ -83,7 +85,7 @@ const uploadAsset = (options) => {
 
 const fn = {
     'upload': async () => {
-        const { owner, repo, tag, name, body } = program;
+        const { owner, repo, tag, name, body, draft, prerelease } = program;
         const files = args;
         let release;
 
@@ -106,7 +108,9 @@ const fn = {
                     repo: repo,
                     tag_name: tag,
                     name: name || tag,
-                    body: body || ''
+                    body: body || '',
+                    draft: draft || false,
+                    prerelease: prerelease || false
                 });
             } else if (body && (release.body !== body)) {
                 console.log('> releases#editRelease');
@@ -116,7 +120,9 @@ const fn = {
                     id: release.id,
                     tag_name: tag,
                     name: name || tag,
-                    body: body || ''
+                    body: body || '',
+                    draft: draft == null ? release.draft : draft,
+                    prerelease: prerelease == null ? release.prerelease : prerelease
                 };
                 release = await editRelease(releaseOptions);
             }
@@ -140,7 +146,7 @@ const fn = {
         }
     },
     'delete': async () => {
-        const { owner, repo, tag, name, body } = program;
+        const { owner, repo, tag, name, body, draft, prerelease } = program;
         const patterns = args;
         let release;
 


### PR DESCRIPTION
I need to create all of my GH releases from CI as drafts. Draft and prerelease options we missing. This PR adds them.

Additionally, draft releases are not returned by the `getReleaseByTag` API so I ported the function over to use `getReleases` with a filter instead.