### PR TITLE
feat: bump version to 2.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-    "presets": ["env", "stage-0"],
-    "plugins": [
-        "transform-runtime"
-    ]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 /lib
 package-lock.json
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 npm-debug.log
 /src
+/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
-sudo: required
-dist: trusty
-group: edge
-
 language: node_js
 
 os:
   - linux
 
 node_js:
-  - '6'
-  - '8'
   - '10'
+  - '12'
 
 before_install:
   - npm install -g npm

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2019 Cheton Wu
+Copyright (c) 2017-2020 Cheton Wu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Run `github-release` with `-h` or `--help` options:
 Usage: github-release <command> [<args>]
 
 Options:
-  -V, --version             output the version number
-  --baseurl <baseurl>       API endpoint (default: "https://api.github.com")
-  -T, --token <token>       OAuth2 token (default: null)
-  -o, --owner <owner>       The repository owner. (default: "")
-  -r, --repo <repo>         The repository name. (default: "")
-  -t, --tag <tag>           The name of the tag.
-  --release-id <id>         The release id.
-  -c, --commitish <value>   Specifies the commitish value for tag. Unused if the tag already exists.
-  -n, --name <name>         The name of the release. (default: "")
-  -b, --body <body>         Text describing the contents of the tag.
-  -d, --draft [value]       `true` makes the release a draft, and `false` publishes the release.
-  -p, --prerelease [value]  `true` to identify the release as a prerelease, `false` to identify the release as a full release.
-  -h, --help                output usage information
+  -V, --version          output the version number
+  --baseurl <baseurl>    API endpoint (default: "https://api.github.com")
+  --token <token>        OAuth2 token (default: null)
+  --owner <owner>        The repository owner. (default: "")
+  --repo <repo>          The repository name. (default: "")
+  --tag <tag>            The name of the tag.
+  --commitish <value>    Specifies the commitish value for tag. Unused if the tag already exists.
+  --release-id <id>      The release id.
+  --release-name <name>  The name of the release. (default: "")
+  --body <body>          Text describing the contents of the tag.
+  --draft [value]        `true` makes the release a draft, and `false` publishes the release.
+  --prerelease [value]   `true` to identify the release as a prerelease, `false` to identify the release as a full release.
+  -h, --help             display help for command
 ```
 
 ## Commands
@@ -50,7 +50,7 @@ github-release upload \
   --owner cheton \
   --repo github-release-cli \
   --tag "v0.1.0" \
-  --name "v0.1.0" \
+  --release-name "v0.1.0" \
   --body "This release contains bug fixes and imporvements, including:\n..." \
   archive.zip index.html app.min.css app.min.js
 ```
@@ -63,7 +63,7 @@ github-release upload \
     --repo github-release-cli \
     --commitish 6a8e375 \
     --tag "v0.1.0" \
-    --name "v0.1.0" \
+    --release-name "v0.1.0" \
     --body "The commitish value for tag"
 ```
 
@@ -74,7 +74,7 @@ github-release upload \
   --owner cheton \
   --repo github-release-cli \
   --tag "v0.1.0" \
-  --name "v0.1.0" \
+  --release-name "v0.1.0" \
   --body "This is a prerelease" \
   --prerelease
 ```
@@ -86,7 +86,7 @@ github-release upload \
   --owner cheton \
   --repo github-release-cli \
   --tag "v0.1.0" \
-  --name "v0.1.0" \
+  --release-name "v0.1.0" \
   --body "This is a published release" \
   --prerelease=false
 ```
@@ -169,7 +169,7 @@ github-release upload \
   --owner=cheton \
   --repo=github-release-cli \
   --tag="latest" \
-  --name="${TRAVIS_BRANCH}" \
+  --release-name="${TRAVIS_BRANCH}" \
   --body="${COMMIT_LOG}" \
   "releases/myapp-0.1.0-win-x32.exe" \
   "releases/myapp-0.1.0-win-x64.exe"

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '@trendmicro/babel-config',
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        useBuiltIns: 'entry',
+        corejs: 3,
+      }
+    ],
+  ],
+  plugins: [
+    '@babel/plugin-transform-runtime',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "babel --out-dir ./lib ./src",
-    "test": "tap test/*.js --no-timeout --node-arg=--require --node-arg=babel-register --node-arg=--require --node-arg=babel-polyfill",
+    "test": "tap test/*.js --node-arg=--require --node-arg=@babel/register",
     "test:list": "npm run build && node lib/index.js -a --owner cheton --repo github-release-cli list"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/cli": "~7.11.6",
+    "@babel/core": "~7.11.6",
     "@babel/plugin-transform-runtime": "~7.11.5",
     "@babel/preset-env": "~7.11.5",
     "@trendmicro/babel-config": "~1.0.0-alpha",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/core": "~7.11.6",
     "@babel/plugin-transform-runtime": "~7.11.5",
     "@babel/preset-env": "~7.11.5",
+    "@babel/register": "~7.11.5",
     "@trendmicro/babel-config": "~1.0.0-alpha",
     "tap": "^14.10.8"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-release-cli",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "A command-line tool for managing release assets on a GitHub repository",
   "homepage": "https://github.com/cheton/github-release-cli",
   "author": "Cheton Wu <cheton@gmail.com>",
@@ -29,21 +29,21 @@
     "cli"
   ],
   "dependencies": {
-    "@octokit/rest": "^16.23.2",
+    "@octokit/rest": "^18.0.6",
     "babel-runtime": "^6.26.0",
-    "chalk": "^2.4.2",
-    "commander": "^2.20.0",
+    "chalk": "^4.1.0",
+    "commander": "^6.1.0",
     "http-link-header": "^1.0.2",
-    "mime-types": "^2.1.22",
+    "mime-types": "^2.1.27",
     "minimatch": "^3.0.4",
-    "ora": "^3.4.0",
-    "url-parse": "^1.4.4"
+    "ora": "^5.1.0",
+    "url-parse": "^1.4.7"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-stage-0": "^6.24.1",
-    "tap": "^12.6.1"
+    "@babel/cli": "~7.11.6",
+    "@babel/plugin-transform-runtime": "~7.11.5",
+    "@babel/preset-env": "~7.11.5",
+    "@trendmicro/babel-config": "~1.0.0-alpha",
+    "tap": "^14.10.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 /* eslint max-len: 0 */
 import fs from 'fs';
 import path from 'path';
-import Octokit from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import chalk from 'chalk';
 import program from 'commander';
 import * as LinkHeader from 'http-link-header';
@@ -16,21 +16,21 @@ program
     .version(pkg.version)
     .usage('<command> [<args>]')
     .option('--baseurl <baseurl>', 'API endpoint', 'https://api.github.com')
-    .option('-T, --token <token>', 'OAuth2 token', null)
-    .option('-o, --owner <owner>', 'The repository owner.', '')
-    .option('-r, --repo <repo>', 'The repository name.', '')
-    .option('-t, --tag <tag>', 'The name of the tag.')
+    .option('--token <token>', 'OAuth2 token', null)
+    .option('--owner <owner>', 'The repository owner.', '')
+    .option('--repo <repo>', 'The repository name.', '')
+    .option('--tag <tag>', 'The name of the tag.')
+    .option('--commitish <value>', 'Specifies the commitish value for tag. Unused if the tag already exists.')
     .option('--release-id <id>', 'The release id.')
-    .option('-c, --commitish <value>', 'Specifies the commitish value for tag. Unused if the tag already exists.')
-    .option('-n, --name <name>', 'The name of the release.', '') // Note: name is a reserved word and it has to specify a default value.
-    .option('-b, --body <body>', 'Text describing the contents of the tag.')
-    .option('-d, --draft [value]', '`true` makes the release a draft, and `false` publishes the release.', function(val) {
+    .option('--release-name <name>', 'The name of the release.', '')
+    .option('--body <body>', 'Text describing the contents of the tag.')
+    .option('--draft [value]', '`true` makes the release a draft, and `false` publishes the release.', function(val) {
         if (String(val).toLowerCase() === 'false') {
             return false;
         }
         return true;
     })
-    .option('-p, --prerelease [value]', '`true` to identify the release as a prerelease, `false` to identify the release as a full release.', function(val) {
+    .option('--prerelease [value]', '`true` to identify the release as a prerelease, `false` to identify the release as a full release.', function(val) {
         if (String(val).toLowerCase() === 'false') {
             return false;
         }
@@ -97,7 +97,17 @@ const getReleaseByTag = async ({ owner, repo, tag }) => {
 
 const fn = {
     'upload': async () => {
-        const { owner, repo, tag, commitish, name, body, draft, prerelease, releaseId } = program;
+        const {
+            owner,
+            repo,
+            tag,
+            commitish,
+            releaseId,
+            releaseName,
+            body,
+            draft,
+            prerelease,
+        } = program;
         const files = args;
         let release;
 
@@ -116,26 +126,26 @@ const fn = {
 
         try {
             if (!release) {
-                console.log(`> createRelease: tag_name=${tag}, target_commitish=${commitish || ''}, name=${name || tag}, draft=${!!draft}, prerelease=${!!prerelease}`);
+                console.log(`> createRelease: tag_name=${tag}, target_commitish=${commitish || ''}, name=${releaseName || tag}, draft=${!!draft}, prerelease=${!!prerelease}`);
                 const res = await octokit.repos.createRelease({
                     owner,
                     repo,
                     tag_name: tag,
                     target_commitish: commitish,
-                    name: name || tag,
+                    name: releaseName || tag,
                     body: body || '',
                     draft: !!draft,
                     prerelease: !!prerelease,
                 });
                 release = res.data;
             } else {
-                console.log(`> updateRelease: release_id=${release.id}, tag_name=${tag}, name=${name || tag}`);
+                console.log(`> updateRelease: release_id=${release.id}, tag_name=${tag}, name=${releaseName || tag}`);
                 const res = await octokit.repos.updateRelease({
                     owner,
                     repo,
                     release_id: release.id,
                     tag_name: tag,
-                    name: name || tag,
+                    name: releaseName || tag,
                     body: (body === undefined) ? release.body || '' : body || '',
                     draft: (draft === undefined) ? !!release.draft : false,
                     prerelease: (prerelease === undefined) ? !!release.prerelease : false,
@@ -195,12 +205,12 @@ const fn = {
 
         try {
             const release_id = release.id;
-            console.log(`> listAssetsForRelease: release_id=${release_id}`);
+            console.log(`> listReleaseAssets: release_id=${release_id}`);
 
             let assets = [];
             let page = 1;
             do {
-                const res = await octokit.repos.listAssetsForRelease({ owner, repo, release_id, page });
+                const res = await octokit.repos.listReleaseAssets({ owner, repo, release_id, page });
                 assets = assets.concat(res.data);
                 page = getNextPage(res);
             } while (page)

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ const fn = {
                     console.log(`  #${i + 1}: name="${path.basename(file)}" filePath="${file}"`);
                     await octokit.repos.uploadReleaseAsset({
                         url: release.upload_url,
-                        file: fs.createReadStream(file),
+                        data: fs.createReadStream(file),
                         headers: {
                             'Content-Type': mime.lookup(file) || 'application/octet-stream',
                             'Content-Length': fs.statSync(file).size,


### PR DESCRIPTION
**Breaking Changes**

* Only long option names are supported
``` 
Usage: github-release <command> [<args>]

Options:
  -V, --version          output the version number
  --baseurl <baseurl>    API endpoint (default: "https://api.github.com")
  --token <token>        OAuth2 token (default: null)
  --owner <owner>        The repository owner. (default: "")
  --repo <repo>          The repository name. (default: "")
  --tag <tag>            The name of the tag.
  --commitish <value>    Specifies the commitish value for tag. Unused if the tag already exists.
  --release-id <id>      The release id.
  --release-name <name>  The name of the release. (default: "")
  --body <body>          Text describing the contents of the tag.
  --draft [value]        `true` makes the release a draft, and `false` publishes the release.
  --prerelease [value]   `true` to identify the release as a prerelease, `false` to identify the release as a full release.
  -h, --help             display help for command
```

* Renamed `--name` to `--release-name`