### PR TITLE
feat: replace `babel-runtime` with `@babel/runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "cli"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.13.10",
     "@octokit/rest": "^18.0.6",
-    "babel-runtime": "^6.26.0",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
     "http-link-header": "^1.0.2",


### PR DESCRIPTION
The latest release is broken with the following error:
```
internal/modules/cjs/loader.js:983
  throw err;
  ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireWildcard'
Require stack:
- ~/.nvm/versions/node/v12.16.2/lib/node_modules/github-release-cli/lib/index.js
- ~/.nvm/versions/node/v12.16.2/lib/node_modules/github-release-cli/bin/github-release
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1042:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (~/.nvm/versions/node/v12.16.2/lib/node_modules/github-release-cli/lib/index.js:3:31)
    at Module._compile (internal/modules/cjs/loader.js:1156:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1176:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Module.require (internal/modules/cjs/loader.js:1042:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '~/.nvm/versions/node/v12.16.2/lib/node_modules/github-release-cli/lib/index.js',
    '~.nvm/versions/node/v12.16.2/lib/node_modules/github-release-cli/bin/github-release'
  ]
}
```